### PR TITLE
Add occupied without card enum

### DIFF
--- a/database/migrations/20201221110023_lot_table.js
+++ b/database/migrations/20201221110023_lot_table.js
@@ -4,7 +4,6 @@ const spot_status_enum = [
     'OCCUPIED',
     'OFF_LINE',
     'VIOLATION',
-    'OCCUPIED_WITHOUT_CARD'
 ];
 exports.up = function(knex) {
     return knex.schema.createTable('spots', (tbl)=>{

--- a/database/migrations/20201221110023_lot_table.js
+++ b/database/migrations/20201221110023_lot_table.js
@@ -4,6 +4,7 @@ const spot_status_enum = [
     'OCCUPIED',
     'OFF_LINE',
     'VIOLATION',
+    'OCCUPIED_WITHOUT_CARD'
 ];
 exports.up = function(knex) {
     return knex.schema.createTable('spots', (tbl)=>{

--- a/database/migrations/20221122153439_add_occupied_without_card_enum.js
+++ b/database/migrations/20221122153439_add_occupied_without_card_enum.js
@@ -1,0 +1,46 @@
+const spot_status_enum = [
+    'UNOCCUPIED',
+    'RESERVED',
+    'OCCUPIED',
+    'OFF_LINE',
+    'VIOLATION',
+    'OCCUPIED_WITHOUT_CARD',
+];
+const spot_status_enum_old = [
+    'UNOCCUPIED',
+    'RESERVED',
+    'OCCUPIED',
+    'OFF_LINE',
+    'VIOLATION',
+];
+
+exports.up = async function (knex) {
+    const current_rows = await knex('spots').select('*');
+    await knex.schema.table('spots', (tbl) => tbl.dropColumn('spot_status'));
+    await knex.schema.table('spots', (tbl) => tbl.enum('spot_status', spot_status_enum, {
+        useNative: true,
+        enumName: 'spot_status_enum',
+    }));
+    return await Promise.all(current_rows.map((row) => {
+        return knex('spots')
+            .update({ spot_status: row.spot_status })
+            .where('id', row.id)
+    }));
+}
+
+exports.down = async function (knex) {
+    const current_rows = await knex('spots').select('*');
+    await knex.schema.table('spots', (tbl) => tbl.dropColumn('spot_status'));
+    await knex.schema.table('spots', (tbl) => tbl.enum('spot_status', spot_status_enum_old, {
+        useNative: true,
+        enumName: 'spot_status_enum',
+    }));
+    return await Promise.all(current_rows.map((row) => {
+        return knex('spots')
+            .update({
+                spot_status: row.spot_status ===
+                    'OCCUPIED_WITHOUT_CARD' ? 'OCCUPIED' : row.spot_status
+            })
+            .where('id', row.id)
+    }));
+}


### PR DESCRIPTION
# Administrative Info
Make sure your branch name conforms to: `<feature/hotfix/...>/describe_your_branch_with_underscores

### Changes
What changes did you make?
- Added a migration file to add the "OCCUPIED_WITHOUT_CARD" field to the "spot_status" enum in the "spots" table.

Followed steps already done here: [](https://github.com/Proko-Tech/proko-park-be/pull/75)

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tested my program thoroughly
- [ ] Did you add/sub fields in the environment file? if so please update .env_sample
- [ ] If you alter/added/delete a route in the code base, did you update the api folder in shared drive?

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

- Migration file can be found in root-->database-->migrations-->20221122153439_add_occupied_without_card_enum.js
- Run the migration file and the new field should be seen in the MySQL database.
